### PR TITLE
Enable UseTimestamp true by default on metrics SG

### DIFF
--- a/roles/smartgateway/templates/metrics-configmap.yaml.j2
+++ b/roles/smartgateway/templates/metrics-configmap.yaml.j2
@@ -13,5 +13,6 @@ data:
             "DataCount": {{ data_count | default('-1') }},
             "ServiceType": "{{ service_type | default('metrics') }}",
             "Debug": {{ debug | default('true') }},
-            "Prefetch": {{ prefetch | default('1000') }}
+            "Prefetch": {{ prefetch | default('1000') }},
+            "UseTimestamp": {{ use_timestamp | default('true') }}
     }


### PR DESCRIPTION
Enable timestamps by default when setting up a metrics Smart Gateway